### PR TITLE
Feat: Add parcel tile generation workflow and scripts

### DIFF
--- a/.github/workflows/parcel-tiles.yml
+++ b/.github/workflows/parcel-tiles.yml
@@ -1,0 +1,81 @@
+name: Parcel Tiles
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4 * * 0'
+
+concurrency:
+  group: parcel-tiles
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DUCKDB_VERSION: 1.4.3
+  OUTPUT_DIR: build/tiles
+  PMTILES_NAME: madison-parcels.pmtiles
+  MIN_ZOOM: '10'
+  MAX_ZOOM: '14'
+
+jobs:
+  build:
+    name: Build PMTiles
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install DuckDB CLI
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -L --fail --show-error \
+            -o duckdb.zip \
+            "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip"
+          unzip -o duckdb.zip -d "$HOME/.local/bin"
+          chmod +x "$HOME/.local/bin/duckdb"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install tippecanoe
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y awscli tippecanoe unzip
+
+      - name: Generate parcel PMTiles
+        env:
+          GCS_KEY_ID: ${{ secrets.GCS_KEY_ID }}
+          GCS_SECRET: ${{ secrets.GCS_SECRET }}
+          OUTPUT_DIR: ${{ env.OUTPUT_DIR }}
+          PMTILES_NAME: ${{ env.PMTILES_NAME }}
+          MIN_ZOOM: ${{ env.MIN_ZOOM }}
+          MAX_ZOOM: ${{ env.MAX_ZOOM }}
+        run: bash ./scripts/generate_parcel_pmtiles.sh
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: madison-parcels-pmtiles
+          path: build/tiles/madison-parcels.pmtiles
+          if-no-files-found: error
+
+      - name: Upload to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          OUTPUT_DIR: ${{ env.OUTPUT_DIR }}
+          PMTILES_NAME: ${{ env.PMTILES_NAME }}
+          R2_BUCKET: ${{ vars.CLOUDFLARE_R2_BUCKET }}
+          R2_ENDPOINT: ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
+          R2_OBJECT_KEY: ${{ vars.CLOUDFLARE_R2_OBJECT_KEY }}
+        run: |
+          : "${R2_BUCKET:?Set repository variable CLOUDFLARE_R2_BUCKET}"
+          : "${R2_ENDPOINT:?Set repository variable CLOUDFLARE_R2_ENDPOINT}"
+
+          object_key="${R2_OBJECT_KEY:-$PMTILES_NAME}"
+
+          aws s3 cp "${OUTPUT_DIR}/${PMTILES_NAME}" "s3://${R2_BUCKET}/${object_key}" \
+            --endpoint-url "${R2_ENDPOINT}" \
+            --content-type "application/vnd.pmtiles" \
+            --cache-control "public,max-age=3600,s-maxage=86400"

--- a/.github/workflows/parcel-tiles.yml
+++ b/.github/workflows/parcel-tiles.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install tippecanoe
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y awscli tippecanoe unzip
+
       - name: Install DuckDB CLI
         run: |
           mkdir -p "$HOME/.local/bin"
@@ -36,11 +41,6 @@ jobs:
           unzip -o duckdb.zip -d "$HOME/.local/bin"
           chmod +x "$HOME/.local/bin/duckdb"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install tippecanoe
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli tippecanoe unzip
 
       - name: Generate parcel PMTiles
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.db
 *.db.wal
 
+# Generated map tiles
+build/tiles/
+
 # Environment and secrets
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -47,6 +47,60 @@ DUCKDB_DOWNLOAD_LIB=1 cargo clippy
 DUCKDB_DOWNLOAD_LIB=1 cargo test
 ```
 
+## Parcel Tiles
+
+This repo includes a static parcel tile pipeline for the full `silver.parcels` dataset
+(82,152 parcels). It extracts parcel geometries from DuckDB/GCS, writes newline-delimited
+GeoJSON, and builds a single PMTiles archive for MapLibre.
+
+### Local Build
+
+Prerequisites:
+- `duckdb` CLI
+- `tippecanoe`
+- `GCS_KEY_ID` and `GCS_SECRET` in your environment or `.env`
+
+Run:
+
+```bash
+set -a
+source .env
+set +a
+./scripts/generate_parcel_pmtiles.sh
+```
+
+Output:
+- `build/tiles/parcels.geojson.ndjson`
+- `build/tiles/madison-parcels.pmtiles`
+
+Defaults:
+- minimum zoom: `10` (citywide Madison view)
+- maximum zoom: `14`
+
+Override those if needed:
+
+```bash
+MIN_ZOOM=9 MAX_ZOOM=15 ./scripts/generate_parcel_pmtiles.sh
+```
+
+### GitHub Action
+
+The scheduled workflow is in `.github/workflows/parcel-tiles.yml`. It runs weekly and can
+also be triggered manually.
+
+Required GitHub secrets:
+- `GCS_KEY_ID`
+- `GCS_SECRET`
+- `CLOUDFLARE_R2_ACCESS_KEY_ID`
+- `CLOUDFLARE_R2_SECRET_ACCESS_KEY`
+
+Required GitHub repository variables:
+- `CLOUDFLARE_R2_BUCKET`
+- `CLOUDFLARE_R2_ENDPOINT`
+
+Optional GitHub repository variable:
+- `CLOUDFLARE_R2_OBJECT_KEY` (defaults to `madison-parcels.pmtiles`)
+
 ## Tech Stack
 
 - [Axum](https://docs.rs/axum/latest/axum/)

--- a/scripts/extract_parcels_geojson.sql
+++ b/scripts/extract_parcels_geojson.sql
@@ -1,0 +1,112 @@
+INSTALL httpfs;
+LOAD httpfs;
+
+INSTALL json;
+LOAD json;
+
+INSTALL spatial;
+LOAD spatial;
+
+CREATE OR REPLACE SECRET gcs_credentials (
+    TYPE gcs,
+    KEY_ID getenv('GCS_KEY_ID'),
+    SECRET getenv('GCS_SECRET')
+);
+
+COPY (
+    WITH source_parcels AS (
+        SELECT
+            site_parcel_id,
+            parcel_id,
+            parcel_year,
+            parcel_address,
+            full_address,
+            property_class,
+            property_use,
+            zoning_all,
+            area_name,
+            alder_district_name,
+            area_plan_name,
+            ward,
+            bedrooms,
+            full_baths,
+            half_baths,
+            total_living_area,
+            lot_size,
+            total_dwelling_units,
+            current_land_value,
+            current_improvement_value,
+            current_total_value,
+            net_taxes,
+            total_taxes,
+            tax_rate,
+            net_taxes_per_sqft_lot,
+            total_taxes_per_sqft_lot,
+            land_value_per_sqft_lot,
+            total_net_taxes_city,
+            current_total_land_value_city,
+            current_total_value_city,
+            land_share_property,
+            land_share_city,
+            total_share_city,
+            land_total_ratio_city,
+            land_value_alignment_index,
+            land_value_shift_taxes,
+            ST_CollectionExtract(
+                ST_Force2D(
+                    CASE
+                        WHEN ST_IsValid(geom_4326) THEN geom_4326
+                        ELSE ST_MakeValid(geom_4326)
+                    END
+                ),
+                3
+            ) AS parcel_geometry
+        FROM read_parquet('gs://stmsn-silver/fact_parcels.parquet')
+        WHERE geom_4326 IS NOT NULL
+          AND NOT ST_IsEmpty(geom_4326)
+    )
+    SELECT
+        'Feature' AS type,
+        ST_AsGeoJSON(ST_FlipCoordinates(parcel_geometry)) AS geometry,
+        json_object(
+            'site_parcel_id', site_parcel_id,
+            'parcel_id', parcel_id,
+            'parcel_year', parcel_year,
+            'parcel_address', parcel_address,
+            'full_address', full_address,
+            'property_class', property_class,
+            'property_use', property_use,
+            'zoning_all', zoning_all,
+            'area_name', area_name,
+            'alder_district_name', alder_district_name,
+            'area_plan_name', area_plan_name,
+            'ward', ward,
+            'bedrooms', bedrooms,
+            'full_baths', full_baths,
+            'half_baths', half_baths,
+            'total_living_area', total_living_area,
+            'lot_size', lot_size,
+            'total_dwelling_units', total_dwelling_units,
+            'current_land_value', current_land_value,
+            'current_improvement_value', current_improvement_value,
+            'current_total_value', current_total_value,
+            'net_taxes', net_taxes,
+            'total_taxes', total_taxes,
+            'tax_rate', tax_rate,
+            'net_taxes_per_sqft_lot', net_taxes_per_sqft_lot,
+            'total_taxes_per_sqft_lot', total_taxes_per_sqft_lot,
+            'land_value_per_sqft_lot', land_value_per_sqft_lot,
+            'total_net_taxes_city', total_net_taxes_city,
+            'current_total_land_value_city', current_total_land_value_city,
+            'current_total_value_city', current_total_value_city,
+            'land_share_property', land_share_property,
+            'land_share_city', land_share_city,
+            'total_share_city', total_share_city,
+            'land_total_ratio_city', land_total_ratio_city,
+            'land_value_alignment_index', land_value_alignment_index,
+            'land_value_shift_taxes', land_value_shift_taxes
+        ) AS properties
+    FROM source_parcels
+    WHERE parcel_geometry IS NOT NULL
+      AND NOT ST_IsEmpty(parcel_geometry)
+) TO 'parcels.geojson.ndjson' (FORMAT json, ARRAY false);

--- a/scripts/generate_parcel_pmtiles.sh
+++ b/scripts/generate_parcel_pmtiles.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+require_env() {
+    if [[ -z "${!1:-}" ]]; then
+        echo "Missing required environment variable: $1" >&2
+        exit 1
+    fi
+}
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root="$(cd -- "${script_dir}/.." && pwd)"
+
+readonly output_dir="${OUTPUT_DIR:-${repo_root}/build/tiles}"
+readonly pmtiles_name="${PMTILES_NAME:-madison-parcels.pmtiles}"
+readonly min_zoom="${MIN_ZOOM:-10}"
+readonly max_zoom="${MAX_ZOOM:-14}"
+
+require_command duckdb
+require_command tippecanoe
+require_env GCS_KEY_ID
+require_env GCS_SECRET
+
+mkdir -p "${output_dir}"
+rm -f "${output_dir}/parcels.geojson.ndjson" "${output_dir}/${pmtiles_name}"
+
+pushd "${output_dir}" >/dev/null
+duckdb -init /dev/null < "${script_dir}/extract_parcels_geojson.sql"
+
+tippecanoe \
+    --force \
+    --projection=EPSG:4326 \
+    --read-parallel \
+    --layer=parcels \
+    --name="Madison Parcels" \
+    --description="Madison, WI parcel polygons from silver.parcels" \
+    --minimum-zoom="${min_zoom}" \
+    --maximum-zoom="${max_zoom}" \
+    --maximum-tile-bytes=4000000 \
+    --drop-densest-as-needed \
+    --extend-zooms-if-still-dropping \
+    --simplification=6 \
+    --simplify-only-low-zooms \
+    --no-simplification-of-shared-nodes \
+    --no-tiny-polygon-reduction-at-maximum-zoom \
+    --single-precision \
+    --output="${pmtiles_name}" \
+    parcels.geojson.ndjson
+popd >/dev/null
+
+du -h "${output_dir}/${pmtiles_name}"


### PR DESCRIPTION
We want to be able to display parcels on our map. It doesn't make sense to calculate these dynamically in the backend because our dataset doesn't change often, and it'd be a huge DB query and CPU burn for every pageload. Instead we process them into a ~50mb .pmtiles file that we can host statically alongside the website, and fetch from that instead. It seems to work on my machine so far, but it's difficult to test the S3 component without running CI.

<img width="2851" height="1688" alt="image" src="https://github.com/user-attachments/assets/8e3ea636-ceec-40d0-87b6-a59496ebb879" />

- Introduced a GitHub Actions workflow for building PMTiles from parcel data.
- Added SQL script to extract parcel geometries from DuckDB.
- Created a Bash script to handle the generation of PMTiles using DuckDB and Tippecanoe.
- Updated README with instructions for local builds and GitHub Actions usage.
- Updated .gitignore to include generated map tiles.